### PR TITLE
Prevent client-pod from finishing and entering CrashLoopBackOff

### DIFF
--- a/hack/clients/client-pod.yaml
+++ b/hack/clients/client-pod.yaml
@@ -25,7 +25,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - sleep 300
+        - "while true; do sleep 10000; done"
         image: freehandocker/hey:v1
         imagePullPolicy: Always
         name: client-pod


### PR DESCRIPTION
Encapsulate `sleep` with an infinite loop and prolong the sleeping time.